### PR TITLE
Add Old Pochmann cube solver

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.ipynb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+        files: "\\.(py)$"
+        args: ["--profile", "black", --settings-path=pyproject.toml]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+test:
+	@pytest ./src/tests -vv -rf --maxfail=1
+
+reformat:
+	@isort --line-length 100 .
+	@black --line-length 100 .
+
+clean:
+	@find . -name "__pycache__" | xargs rm -rf
+	@find . -name ".pytest_cache" | xargs rm -rf
+	@find . -name ".mypy_cache" | xargs rm -rf

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Rubik's cube solver** with the aim to **aid learning** a manual **blindfolded solving**.
 
-The cube itself is **represented using a simple 3D array** form because simplicity is paramount. There is **no need for efficient algorithm execution** (hence the relatively trivial representation). The objective is to develop a simple yet **fast assistant that can verify whether a given sequence of moves is valid** by yielding an expected outcome.
+There is **no need for efficient algorithm execution**. The objective is to develop a simple yet **fast assistant that can verify whether a given sequence of moves is valid** by yielding an expected outcome.
 
 ## References
+
+* [`rubik-cube` repository](https://github.com/pglass/cube/tree/main) - A useful dependency to which the Rubik's cube representation has been outsourced.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.black]
+target-version = ["py310"]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
+[flake8]
+max-line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
+Pillow
+black
 click
+flake8
+isort
 more_itertools
+pre-commit
 pytest
 rubik-cube
-Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+click
+more_itertools
+pytest
+rubik-cube
+Pillow

--- a/src/cube.py
+++ b/src/cube.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import TYPE_CHECKING
+
+import more_itertools
+from rubik.cube import Cube as RubikCube
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+
+class InvalidMove(Exception):
+    """Raise when an invalid move is encountered in the string specification."""
+
+
+class Color(enum.Enum):
+    WHITE = "W"
+    ORANGE = "O"
+    GREEN = "G"
+    RED = "R"
+    BLUE = "B"
+    YELLOW = "Y"
+
+    @classmethod
+    def from_string(cls, color_str: str) -> Color:
+        for member in cls:
+            if member.value == color_str:
+                return member
+        raise ValueError(f"unrecognized color: {color_str}")
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclasses.dataclass(frozen=True)
+class Face:
+    piece_colors: list[list[Color]]
+
+    def __post_init__(self) -> None:
+        if not ((len(self.piece_colors) == 3) and all(len(row) == 3 for row in self.piece_colors)):
+            raise ValueError("`piece_colors` is not a 3x3 list of colors")
+
+    def __iter__(self) -> Color:
+        yield from more_itertools.flatten(self.piece_colors)
+
+    def __getitem__(self, index: tuple[int, int]) -> Color:
+        row, col = index
+        return self.piece_colors[row][col]
+
+    def __str__(self) -> str:
+        return "\n".join(" ".join(row.value for row in self.piece_colors))
+
+    @classmethod
+    def from_single_color(cls, color: Color) -> Face:
+        return cls(piece_colors=[[color] * 3 for _ in range(3)])
+
+    def as_flat_str(self) -> str:
+        return "".join(
+            str(piece_colors) for piece_colors in more_itertools.flatten(self.piece_colors)
+        )
+
+
+class Cube:
+    def __init__(
+        self, up: Face, left: Face, front: Face, right: Face, back: Face, down: Face
+    ) -> None:
+        cube_str = self._as_cube_str(up, left, front, right, back, down)
+        self._cube = RubikCube(cube_str)
+
+    def __str__(self) -> str:
+        return str(self._cube)
+
+    def __iter__(self) -> Iterator[Face]:
+        row_face_indices = (0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 5, 5, 5)
+        faces_piece_colors = [[] for _ in range(6)]
+
+        for face_index, row_colors_str in zip(
+            row_face_indices, more_itertools.chunked(self.as_flat_str(), 3)
+        ):
+            faces_piece_colors[face_index].append(
+                [Color.from_string(color_str) for color_str in row_colors_str]
+            )
+        
+        for piece_colors in faces_piece_colors:
+            yield Face(piece_colors)
+
+    @staticmethod
+    def _as_cube_str(up: Face, left: Face, front: Face, right: Face, back: Face, down: Face) -> str:
+        cube_str = up.as_flat_str()
+        cube_str += "".join(
+            str(face[(row, col)])
+            for row in range(3)
+            for face in (left, front, right, back)
+            for col in range(3)
+        )
+        cube_str += down.as_flat_str()
+        return cube_str
+
+    def as_flat_str(self) -> str:
+        return self._cube.flat_str()
+
+    def apply_moves(self, moves: str) -> None:
+        for i, move in enumerate(moves.strip().split()):
+            try:
+                getattr(self, move)()
+            except AttributeError:
+                raise InvalidMove(f"invalid move '{move}' at position {i}")
+
+    def is_solved(self) -> bool:
+        return self._cube.is_solved()
+
+    def L(self) -> None:
+        self._cube.L()
+
+    def Li(self) -> None:
+        self._cube.Li()
+
+    def Lw(self) -> None:
+        self.L()
+        self.M()
+
+    def Lwi(self) -> None:
+        self.Li()
+        self.Mi()
+
+    def R(self) -> None:
+        self._cube.R()
+
+    def Ri(self) -> None:
+        self._cube.Ri()
+
+    def Rw(self) -> None:
+        self.R()
+        self.Mi()
+
+    def Rwi(self) -> None:
+        self.Ri()
+        self.M()
+
+    def U(self) -> None:
+        self._cube.U()
+
+    def Ui(self) -> None:
+        self._cube.Ui()
+
+    def D(self) -> None:
+        self._cube.D()
+
+    def Di(self) -> None:
+        self._cube.Di()
+
+    def Dw(self) -> None:
+        self.D()
+        self.E()
+
+    def Dwi(self) -> None:
+        self.Di()
+        self.Ei()
+
+    def F(self) -> None:
+        self._cube.F()
+
+    def Fi(self) -> None:
+        self._cube.Fi()
+
+    def B(self) -> None:
+        self._cube.B()
+
+    def Bi(self) -> None:
+        self._cube.Bi()
+
+    def M(self) -> None:
+        self._cube.M()
+
+    def Mi(self) -> None:
+        self._cube.Mi()
+
+    def E(self) -> None:
+        self._cube.E()
+
+    def Ei(self) -> None:
+        self._cube.Ei()
+
+
+def make_white_up_green_front_cube() -> Cube:
+    return Cube(
+        up=Face.from_single_color(Color.WHITE),
+        left=Face.from_single_color(Color.ORANGE),
+        front=Face.from_single_color(Color.GREEN),
+        right=Face.from_single_color(Color.RED),
+        back=Face.from_single_color(Color.BLUE),
+        down=Face.from_single_color(Color.YELLOW),
+    )

--- a/src/cube.py
+++ b/src/cube.py
@@ -82,7 +82,7 @@ class Cube:
             faces_piece_colors[face_index].append(
                 [Color.from_string(color_str) for color_str in row_colors_str]
             )
-        
+
         for piece_colors in faces_piece_colors:
             yield Face(piece_colors)
 

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+from PIL import Image, ImageDraw
+
+from cube import Color
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+    from cube import Cube, Face
+
+    PilImage: TypeAlias = Image.Image
+    Draw: TypeAlias = ImageDraw.ImageDraw
+    ColorSpec: TypeAlias = tuple[int, int, int]
+
+COLOR_MAP = {
+    Color.WHITE: (250, 250, 250),
+    Color.ORANGE: (235, 136, 49),
+    Color.GREEN: (49, 235, 117),
+    Color.RED: (236, 49, 86),
+    Color.BLUE: (49, 114, 235),
+    Color.YELLOW: (235, 225, 49),
+}
+
+
+class CubeRenderer:
+    def __init__(
+        self,
+        image_width: 1024,
+        image_height: 768,
+        color_map: dict[Color, ColorSpec] = COLOR_MAP,
+        background_color: ColorSpec = (64, 64, 64),
+        piece_border_color: ColorSpec = (32, 32, 32),
+        border_size_percent: float = 0.02,
+    ) -> None:
+        self.image_width = image_width
+        self.image_height = image_height
+        self.color_map = color_map
+        self.background_color = background_color
+        self.piece_border_color = piece_border_color
+        self.border_size_percent = border_size_percent
+
+    def render(self, cube: Cube) -> PilImage:
+        # The rendered cube is 3 faces tall and 4 faces wide
+        face_side_size = min(self.image_height // 3, self.image_width // 4)
+
+        x_left_start = (self.image_width - face_side_size * 4) // 2
+        y_top_start = (self.image_height - face_side_size * 3) // 2
+
+        image = Image.new(
+            "RGB", size=(self.image_width, self.image_height), color=self.background_color
+        )
+        draw = ImageDraw.Draw(image)
+
+        for (row, col), face in zip(((0, 1), (1, 0), (1, 1), (1, 2), (1, 3), (2, 1)), cube):
+            self._render_face(
+                draw,
+                face,
+                x_left=x_left_start + col * face_side_size,
+                y_top=y_top_start + row * face_side_size,
+                face_side_size=face_side_size,
+            )
+
+        return image
+
+    def _render_face(
+        self, draw: Draw, face: Face, x_left: int, y_top: int, face_side_size: int
+    ) -> None:
+        piece_side_size = face_side_size // 3
+        x_left_start = y_top_start = (face_side_size - piece_side_size * 3) // 2
+
+        border_size = int(round(piece_side_size * self.border_size_percent))
+
+        for (row, col), color in zip(itertools.product(range(3), repeat=2), face):
+            x_1 = x_left + x_left_start + col * piece_side_size
+            y_1 = y_top + y_top_start + row * piece_side_size
+            x_2 = x_1 + piece_side_size
+            y_2 = y_1 + piece_side_size
+            color_rgb = self.color_map[color]
+
+            draw.rectangle((x_1, y_1, x_2, y_2), fill=self.piece_border_color)
+            draw.rectangle(
+                (x_1 + border_size, y_1 + border_size, x_2 - border_size, y_2 - border_size),
+                fill=color_rgb,
+            )

--- a/src/show_cube_state.py
+++ b/src/show_cube_state.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import click
 
 from cube import make_white_up_green_front_cube
-from solver import OldPochmannSolver
 from renderer import CubeRenderer
+from solver import OldPochmannSolver
 
 
 @click.command()
@@ -57,7 +57,7 @@ def main(
     if reverse_swap_letters:
         edge_swap_letters = reverse_str(edge_swap_letters)
         corner_swap_letters = reverse_str(corner_swap_letters)
-    
+
     solver.solve(cube, edge_swap_letters, corner_swap_letters, corners_first, apply_parity)
     cube_image = renderer.render(cube)
 

--- a/src/show_cube_state.py
+++ b/src/show_cube_state.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import click
+
+from cube import make_white_up_green_front_cube
+from solver import OldPochmannSolver
+from renderer import CubeRenderer
+
+
+@click.command()
+@click.argument("edge_swap_letters", type=str)
+@click.argument("corner_swap_letters", type=str)
+@click.option(
+    "--corners-first",
+    is_flag=True,
+    help="indicates whether to apply corner swaps before edge swaps",
+)
+@click.option(
+    "--reverse-swap-letters",
+    is_flag=True,
+    help="indicates whether to reverse swap letter sequences (useful for verifying solves)",
+)
+@click.option(
+    "--apply-parity",
+    is_flag=True,
+    help="indicates whether to apply parity if there is an odd number of swaps",
+)
+@click.option(
+    "-w",
+    "--image-width",
+    type=int,
+    default=1024,
+    show_default=True,
+    help="width of the rendered image",
+)
+@click.option(
+    "-h",
+    "--image-height",
+    type=int,
+    default=768,
+    show_default=True,
+    help="height of the rendered image",
+)
+def main(
+    edge_swap_letters: str,
+    corner_swap_letters: str,
+    corners_first: bool,
+    reverse_swap_letters: bool,
+    apply_parity: bool,
+    image_width: int,
+    image_height: int,
+) -> None:
+    cube = make_white_up_green_front_cube()
+    solver = OldPochmannSolver()
+    renderer = CubeRenderer(image_width, image_height)
+
+    if reverse_swap_letters:
+        edge_swap_letters = reverse_str(edge_swap_letters)
+        corner_swap_letters = reverse_str(corner_swap_letters)
+    
+    solver.solve(cube, edge_swap_letters, corner_swap_letters, corners_first, apply_parity)
+    cube_image = renderer.render(cube)
+
+    cube_image.show(title="Rubik's Cube Preview")
+
+
+def reverse_str(s: str) -> str:
+    return "".join(reversed(s))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/solver.py
+++ b/src/solver.py
@@ -18,8 +18,12 @@ class SetupMove:
         def count_moves(moves: str) -> int:
             return len(moves.strip().split())
 
-        if count_moves(self.moves) != count_moves(self.inverse_moves):
-            raise ValueError(f"no. of moves does not equal the no. of inverse moves")
+        n_moves = count_moves(self.moves)
+        n_inverse_moves = count_moves(self.inverse_moves)
+        if n_moves != n_inverse_moves:
+            raise ValueError(
+                f"no. of moves {n_moves} does not equal the no. of inverse moves {n_inverse_moves}"
+            )
 
 
 EDGE_SWAP_MOVES = "R U Ri Ui Ri F R R Ui Ri Ui R U Ri Fi"

--- a/src/solver.py
+++ b/src/solver.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Iterator
+
+    from cube import Cube
+
+
+@dataclasses.dataclass(frozen=True)
+class SetupMove:
+    moves: str
+    inverse_moves: str
+
+    def __post_init__(self) -> None:
+        def count_moves(moves: str) -> int:
+            return len(moves.strip().split())
+
+        if count_moves(self.moves) != count_moves(self.inverse_moves):
+            raise ValueError(f"no. of moves does not equal the no. of inverse moves")
+
+
+EDGE_SWAP_MOVES = "R U Ri Ui Ri F R R Ui Ri Ui R U Ri Fi"
+CORNER_SWAP_MOVES = "R Ui Ri Ui R U Ri Fi R U Ri Ui Ri F R"
+PARITY_MOVES = "R U Ri Fi R U U Ri U U Ri F R U R U U Ri Ui"
+
+EDGE_SETUP_MOVES = {
+    "A": SetupMove("Lw Lw Di L L", "L L D Lw Lw"),
+    "C": SetupMove("Lw Lw D L L", "L L Di Lw Lw"),
+    "D": SetupMove("", ""),
+    "E": SetupMove("L Dwi L", "Li Dw Li"),
+    "F": SetupMove("Dwi L", "Li Dw"),
+    "G": SetupMove("Li Dwi L", "Li Dw L"),
+    "H": SetupMove("Dw Li", "L Dwi"),
+    "I": SetupMove("Lw Lw Di L L", "L L D Lw Lw"),
+    "J": SetupMove("Dw Dw L", "Li Dwi Dwi"),
+    "K": SetupMove("Lw D L L", "L L Di Lwi"),
+    "L": SetupMove("Li", "L"),
+    "N": SetupMove("Dw L", "Li Dwi"),
+    "O": SetupMove("Di Di Li Dwi L", "Li Dw L D D"),
+    "P": SetupMove("Dwi Li", "L Dw"),
+    "R": SetupMove("Lwi D L L", "L L Di Lw"),
+    "S": SetupMove("L", "Li"),
+    "T": SetupMove("Lwi Di L L", "Li Li D Lw"),
+    "U": SetupMove("Dwi Dwi Li", "L Dw Dw"),
+    "V": SetupMove("Di L L", "L L D"),
+    "W": SetupMove("D D L L", "L L D D"),
+    "Y": SetupMove("D L L", "L L Di"),
+    "Z": SetupMove("L L", "L L"),
+}
+
+CORNER_SETUP_MOVES = {
+    "B": SetupMove("R R", "R R"),
+    "C": SetupMove("F F D", "Di F F"),
+    "D": SetupMove("F F", "F F"),
+    "F": SetupMove("Fi D", "Di F"),
+    "G": SetupMove("Fi", "F"),
+    "H": SetupMove("Di R", "Ri D"),
+    "I": SetupMove("F Ri", "R Fi"),
+    "J": SetupMove("Ri", "R"),
+    "K": SetupMove("Fi Ri", "R F"),
+    "L": SetupMove("F F Ri", "R Fi Fi"),
+    "M": SetupMove("F", "Fi"),
+    "N": SetupMove("Ri F", "Fi R"),
+    "O": SetupMove("Ri Ri F", "Fi R R"),
+    "P": SetupMove("R F", "Fi Ri"),
+    "R": SetupMove("R Di", "D Ri"),
+    "T": SetupMove("D Fi", "F Di"),
+    "U": SetupMove("R", "Ri"),
+    "V": SetupMove("D", "Di"),
+    "W": SetupMove("", ""),
+    "Y": SetupMove("Di", "D"),
+    "Z": SetupMove("D D", "Di Di"),
+}
+
+
+class OldPochmannSolver:
+    def __init__(
+        self,
+        edge_swap_moves: str = EDGE_SWAP_MOVES,
+        corner_swap_moves: str = CORNER_SWAP_MOVES,
+        parity_moves: str = PARITY_MOVES,
+        edge_setup_moves_mapping: dict[str, SetupMove] = EDGE_SETUP_MOVES,
+        corner_setup_moves_mapping: dict[str, SetupMove] = CORNER_SETUP_MOVES,
+    ) -> None:
+        self.edge_swap_moves = edge_swap_moves
+        self.corner_swap_moves = corner_swap_moves
+        self.parity_moves = parity_moves
+        self.edge_setup_moves_mapping = edge_setup_moves_mapping
+        self.corner_setup_moves_mapping = corner_setup_moves_mapping
+
+    def solve(
+        self,
+        cube: Cube,
+        edge_swap_letters: str,
+        corner_swap_letters: str,
+        corners_first: bool = False,
+        apply_parity: bool = True,
+    ) -> None:
+        moves = self.swaps_to_moves(
+            edge_swap_letters, corner_swap_letters, corners_first, apply_parity
+        )
+        cube.apply_moves(moves)
+
+    def swaps_to_moves(
+        self,
+        edge_swap_letters: str,
+        corner_swap_letters: str,
+        corners_first: bool = False,
+        apply_parity: bool = True,
+    ) -> str:
+        edge_setup_moves = [
+            self.edge_setup_moves_mapping[swap_letter] for swap_letter in edge_swap_letters
+        ]
+        corner_setup_moves = [
+            self.corner_setup_moves_mapping[swap_letter] for swap_letter in corner_swap_letters
+        ]
+
+        setup_moves_1, commutator_moves_1 = edge_setup_moves, self.edge_swap_moves
+        setup_moves_2, commutator_moves_2 = corner_setup_moves, self.corner_swap_moves
+        if corners_first:
+            setup_moves_1, setup_moves_2 = setup_moves_2, setup_moves_1
+            commutator_moves_1, commutator_moves_2 = commutator_moves_2, commutator_moves_1
+
+        moves_list = list(
+            self._interleave_setup_moves_with_commutator(setup_moves_1, commutator_moves_1)
+        )
+        if apply_parity and (len(edge_swap_letters) % 2 == 1):
+            moves_list.append(self.parity_moves)
+        moves_list.extend(
+            self._interleave_setup_moves_with_commutator(setup_moves_2, commutator_moves_2)
+        )
+
+        moves = " ".join(moves_list)
+
+        return moves
+
+    @staticmethod
+    def _interleave_setup_moves_with_commutator(
+        setup_moves: Iterable[SetupMove], commutator_moves: str
+    ) -> Iterator[str]:
+        for setup_move in setup_moves:
+            yield setup_move.moves
+            yield commutator_moves
+            yield setup_move.inverse_moves

--- a/src/tests/cube_test.py
+++ b/src/tests/cube_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from cube import InvalidMove, make_white_up_green_front_cube
+
+
+class TestCube:
+    @pytest.fixture
+    def cube(self):
+        return make_white_up_green_front_cube()
+
+    def test_as_flat_str(self, cube):
+        assert cube.as_flat_str() == (
+            "WWWWWWWWW" + "OOOGGGRRRBBB" + "OOOGGGRRRBBB" + "OOOGGGRRRBBB" + "YYYYYYYYY"
+        )
+
+    def test_is_solved(self, cube):
+        assert cube.is_solved()
+
+    @pytest.mark.parametrize(
+        "move_method_name, expected_flat_str",
+        [
+            pytest.param(
+                "L",
+                "BWWBWWBWW" + "OOOWGGRRRBBY" + "OOOWGGRRRBBY" + "OOOWGGRRRBBY" + "GYYGYYGYY",
+                id="L",
+            ),
+            pytest.param(
+                "Lw",
+                "BBWBBWBBW" + "OOOWWGRRRBYY" + "OOOWWGRRRBYY" + "OOOWWGRRRBYY" + "GGYGGYGGY",
+                id="Lw",
+            ),
+            pytest.param(
+                "Rw",
+                "WGGWGGWGG" + "OOOGYYRRRWWB" + "OOOGYYRRRWWB" + "OOOGYYRRRWWB" + "YBBYBBYBB",
+                id="Rw",
+            ),
+            pytest.param(
+                "Dw",
+                "WWWWWWWWW" + "OOOGGGRRRBBB" + "BBBOOOGGGRRR" + "BBBOOOGGGRRR" + "YYYYYYYYY",
+                id="Dw",
+            ),
+        ],
+    )
+    def test_single_move(self, cube, move_method_name, expected_flat_str):
+        getattr(cube, move_method_name)()
+        assert cube.as_flat_str() == expected_flat_str
+
+    @pytest.mark.parametrize(
+        "moves, expected_flat_str",
+        [
+            pytest.param(
+                "L",
+                "BWWBWWBWW" + "OOOWGGRRRBBY" + "OOOWGGRRRBBY" + "OOOWGGRRRBBY" + "GYYGYYGYY",
+                id="L",
+            ),
+            pytest.param(
+                "L D",
+                "BWWBWWBWW" + "OOOWGGRRRBBY" + "OOOWGGRRRBBY" + "BBYOOOWGGRRR" + "GGGYYYYYY",
+                id="LD",
+            ),
+        ],
+    )
+    def test_apply_moves(self, cube, moves, expected_flat_str):
+        cube.apply_moves(moves)
+        assert cube.as_flat_str() == expected_flat_str
+
+    @pytest.mark.parametrize("moves", ["?!", ".,/", "QW"])
+    def test_apply_moves_raises_invalid_move(self, cube, moves):
+        with pytest.raises(InvalidMove):
+            cube.apply_moves(moves)

--- a/src/tests/renderer_test.py
+++ b/src/tests/renderer_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from cube import make_white_up_green_front_cube
+from renderer import CubeRenderer
+
+
+class TestCubeRenderer:
+    @pytest.fixture
+    def cube(self):
+        return make_white_up_green_front_cube()
+
+    @pytest.fixture
+    def renderer(self):
+        return CubeRenderer(image_width=800, image_height=600)
+
+    def test_image_size_matches(self, cube, renderer):
+        image = renderer.render(cube)
+        assert image.size == (800, 600)

--- a/src/tests/solver_test.py
+++ b/src/tests/solver_test.py
@@ -104,7 +104,8 @@ class TestRealOldPochmannSolver:
         return make_white_up_green_front_cube()
 
     @pytest.mark.parametrize(
-        "edge_swap_letters, corner_swap_letters, corners_first, apply_parity, expected_cube_flat_str",
+        "edge_swap_letters, corner_swap_letters, "
+        "corners_first, apply_parity, expected_cube_flat_str",
         [
             pytest.param(
                 "D",

--- a/src/tests/solver_test.py
+++ b/src/tests/solver_test.py
@@ -1,0 +1,164 @@
+import pytest
+
+from cube import make_white_up_green_front_cube
+from solver import (
+    CORNER_SETUP_MOVES,
+    CORNER_SWAP_MOVES,
+    EDGE_SETUP_MOVES,
+    EDGE_SWAP_MOVES,
+    PARITY_MOVES,
+    OldPochmannSolver,
+    SetupMove,
+)
+
+
+class TestDummyOldPochmannSolver:
+    TEST_EDGE_SWAP_MOVES = "<edge-swap>"
+    TEST_CORNER_SWAP_MOVES = "<corner-swap>"
+    TEST_PARITY_MOVES = "<parity-resolve>"
+    TEST_EDGE_SETUP_MOVES_MAPPING = {
+        "A": SetupMove("edge-setup-1", "edge-setup-1-inv"),
+        "B": SetupMove("edge-setup-2", "edge-setup-2-inv"),
+    }
+    TEST_CORNER_SETUP_MOVES_MAPPING = {
+        "C": SetupMove("corner-setup-1", "corner-setup-1-inv"),
+        "D": SetupMove("corner-setup-2", "corner-setup-2-inv"),
+    }
+
+    @pytest.fixture
+    def old_pochmann_solver(self):
+        return OldPochmannSolver(
+            self.TEST_EDGE_SWAP_MOVES,
+            self.TEST_CORNER_SWAP_MOVES,
+            self.TEST_PARITY_MOVES,
+            self.TEST_EDGE_SETUP_MOVES_MAPPING,
+            self.TEST_CORNER_SETUP_MOVES_MAPPING,
+        )
+
+    @pytest.mark.parametrize(
+        "edge_swap_letters, corner_swap_letters, corners_first, expected_moves",
+        [
+            pytest.param(
+                "A",
+                "C",
+                False,
+                "edge-setup-1 <edge-swap> edge-setup-1-inv "
+                "<parity-resolve> "
+                "corner-setup-1 <corner-swap> corner-setup-1-inv",
+                id="single_edge_single_corner",
+            ),
+            pytest.param(
+                "A",
+                "C",
+                True,
+                "corner-setup-1 <corner-swap> corner-setup-1-inv "
+                "<parity-resolve> "
+                "edge-setup-1 <edge-swap> edge-setup-1-inv",
+                id="single_edge_single_corner_reversed",
+            ),
+            pytest.param(
+                "AB",
+                "CD",
+                False,
+                "edge-setup-1 <edge-swap> edge-setup-1-inv "
+                "edge-setup-2 <edge-swap> edge-setup-2-inv "
+                "corner-setup-1 <corner-swap> corner-setup-1-inv "
+                "corner-setup-2 <corner-swap> corner-setup-2-inv",
+                id="two_edges_two_corners",
+            ),
+            pytest.param(
+                "AB",
+                "CD",
+                True,
+                "corner-setup-1 <corner-swap> corner-setup-1-inv "
+                "corner-setup-2 <corner-swap> corner-setup-2-inv "
+                "edge-setup-1 <edge-swap> edge-setup-1-inv "
+                "edge-setup-2 <edge-swap> edge-setup-2-inv",
+                id="two_edges_two_corners_reversed",
+            ),
+        ],
+    )
+    def test_swaps_to_moves(
+        self,
+        old_pochmann_solver,
+        edge_swap_letters,
+        corner_swap_letters,
+        corners_first,
+        expected_moves,
+    ):
+        moves = old_pochmann_solver.swaps_to_moves(
+            edge_swap_letters, corner_swap_letters, corners_first=corners_first
+        )
+        assert moves == expected_moves
+
+
+class TestRealOldPochmannSolver:
+    @pytest.fixture
+    def old_pochmann_solver(self):
+        return OldPochmannSolver(
+            EDGE_SWAP_MOVES, CORNER_SWAP_MOVES, PARITY_MOVES, EDGE_SETUP_MOVES, CORNER_SETUP_MOVES
+        )
+
+    @pytest.fixture
+    def cube(self):
+        return make_white_up_green_front_cube()
+
+    @pytest.mark.parametrize(
+        "edge_swap_letters, corner_swap_letters, corners_first, apply_parity, expected_cube_flat_str",
+        [
+            pytest.param(
+                "D",
+                "",
+                False,
+                False,
+                "WWWWWWWWW" + "OROGGRBOGRBB" + "OOOGGGRRRBBB" + "OOOGGGRRRBBB" + "YYYYYYYYY",
+                id="T_perm",
+            ),
+            pytest.param(
+                "",
+                "W",
+                False,
+                False,
+                "RWWWWWWWW" + "YBOGGGRRRBOG" + "OOOGGGRRRBBB" + "OOOGGBWRRBBB" + "YYOYYYYYY",
+                id="Y_perm",
+            ),
+            pytest.param(
+                "L",
+                "",
+                False,
+                False,
+                "WWWWWGWWW" + "OOOGGRBOGRBB" + "OORWGGRRRBBB" + "OOOGGGRRRBBB" + "YYYYYYYYY",
+                id="single_corner_swap_L",
+            ),
+            pytest.param(
+                "AC",
+                "",
+                False,
+                False,
+                "WWWWWWWWW" + "OOOGBGRGRBRB" + "OOOGGGRRRBBB" + "OOOGGGRRRBBB" + "YYYYYYYYY",
+                id="three_corner_cycle_up_layer",
+            ),
+            pytest.param(
+                "D",
+                "W",
+                False,
+                False,
+                "RWWWWWWWW" + "YBOGGRBOGRRG" + "OOOGGGRRRBBB" + "OOOGGBWRRBBB" + "YYOYYYYYY",
+                id="D_edge_W_corner_no_setup",
+            ),
+        ],
+    )
+    def test_solve(
+        self,
+        old_pochmann_solver,
+        cube,
+        edge_swap_letters,
+        corner_swap_letters,
+        corners_first,
+        apply_parity,
+        expected_cube_flat_str,
+    ):
+        old_pochmann_solver.solve(
+            cube, edge_swap_letters, corner_swap_letters, corners_first, apply_parity
+        )
+        assert cube.as_flat_str() == expected_cube_flat_str


### PR DESCRIPTION
Add the initial version of the application that applies the Old Pochmann method to solve a Rubik's cube based on a custom letter scheme. The app may also be exploited to verify whether a given solve specified by a sequence of letter swaps is valid by manually inspecting the cube.